### PR TITLE
Delay in-between clicks on Update to avoid client crashes

### DIFF
--- a/VFXEditor/FileManager/FileManagerDocument.cs
+++ b/VFXEditor/FileManager/FileManagerDocument.cs
@@ -38,6 +38,10 @@ namespace VfxEditor.FileManager {
 
         protected DateTime LastUpdate = DateTime.Now;
 
+        protected bool HasBeenUpdated = false;
+
+        protected readonly int SecDelay = 1;
+
         public FileManagerDocument( FileManagerBase manager, string writeLocation ) {
             Manager = manager;
             WriteLocation = writeLocation;
@@ -143,7 +147,7 @@ namespace VfxEditor.FileManager {
         protected void ExportRaw() => UiUtils.WriteBytesDialog( $".{Extension}", File.ToBytes(), Extension, "ExportedFile" );
 
         public void Update() {
-            if( ( DateTime.Now - LastUpdate ).TotalSeconds <= 0.2 ) return;
+            HasBeenUpdated = true;
             LastUpdate = DateTime.Now;
 
             File?.Update();
@@ -402,8 +406,11 @@ namespace VfxEditor.FileManager {
         // ==========================
 
         protected virtual void DisplayFileControls() {
-            if( UiUtils.OkButton( "UPDATE" ) ) Update();
-
+            using( var disabled = ImRaii.Disabled( HasBeenUpdated && ( DateTime.Now - LastUpdate ).TotalSeconds <= SecDelay ) )
+            {
+                if( UiUtils.OkButton( "UPDATE" ) ) Update();
+            }
+            
             using( var spacing = ImRaii.PushStyle( ImGuiStyleVar.ItemSpacing, ImGui.GetStyle().ItemInnerSpacing ) ) {
                 ImGui.SameLine();
             }


### PR DESCRIPTION
When clicking fast, sometimes(often) the Penumbra hook runs into an issue and locks the client and/or crashes it altogether.
I propose the following:

[ffxiv_dx11_sxXQQwuqMJ.webm](https://github.com/user-attachments/assets/ef04b385-37b1-498c-b84c-ebfe7ba949c7)

Tested spam clicking without delay: very frequent crashes
Tested spam clicking with the delay: no crash